### PR TITLE
Bugfix/validation for email field

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -5,7 +5,7 @@ from wtforms.validators import DataRequired, Email
 class ContactForm(FlaskForm):
     name = StringField('Name')
     phone = StringField('Phone')
-    email = StringField('Email', validators=[Email(message='Invalid email address')])
+    email = StringField('Email', validators=[Email(message='Invalid email address!')])
     type = SelectField('Type', 
                       choices=[('Personal', 'Personal'), 
                               ('Work', 'Work'), 

--- a/forms.py
+++ b/forms.py
@@ -1,10 +1,11 @@
 from flask_wtf import FlaskForm
 from wtforms import StringField, SelectField, SubmitField
+from wtforms.validators import DataRequired, Email
 
 class ContactForm(FlaskForm):
     name = StringField('Name')
     phone = StringField('Phone')
-    email = StringField('Email')
+    email = StringField('Email', validators=[Email(message='Invalid email address')])
     type = SelectField('Type', 
                       choices=[('Personal', 'Personal'), 
                               ('Work', 'Work'), 


### PR DESCRIPTION
Bug: No input validation for the email field. Users are able to input invalid emails for contacts.

The bug has been fixed by importing wtforms.validators library and use it to validate the email field. And also, provide a message output in case of invalid input.