### PR TITLE
Fix: Empty Phone Number Field

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -4,7 +4,7 @@ from wtforms.validators import DataRequired, Email
 
 class ContactForm(FlaskForm):
     name = StringField('Name')
-    phone = StringField('Phone')
+    phone = StringField('Phone', validators=[DataRequired(message='Phone number is required!')])
     email = StringField('Email', validators=[Email(message='Invalid email address!')])
     type = SelectField('Type', 
                       choices=[('Personal', 'Personal'), 


### PR DESCRIPTION
To ensure that the phone number field is required, we needed to add the DataRequired validator from wtforms.validators Library to the phone field in the ContactForm class.