### PR TITLE
Fix: No Input Validation for Contact Name

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -1,9 +1,14 @@
 from flask_wtf import FlaskForm
 from wtforms import StringField, SelectField, SubmitField
-from wtforms.validators import DataRequired, Email
+from wtforms.validators import DataRequired, Email, ValidationError
+import re
+
+def validate_name(form, field):
+    if field.data and not re.fullmatch(r"[A-Za-z\s'-]+", field.data):  
+        raise ValidationError('Name must contain only letters, spaces, hyphens, and apostrophes!')
 
 class ContactForm(FlaskForm):
-    name = StringField('Name')
+    name = StringField('Name', validators=[validate_name])
     phone = StringField('Phone', validators=[DataRequired(message='Phone number is required!')])
     email = StringField('Email', validators=[Email(message='Invalid email address!')])
     type = SelectField('Type', 


### PR DESCRIPTION
A new custom validation function (validate_name) was added to restrict names to letters, spaces, hyphens, and apostrophes using Regex. If the user enters invalid value in the Contact name field, error output will be also displayed.
